### PR TITLE
Fix PB deltas, avoid duplicated runs

### DIFF
--- a/src/main.as
+++ b/src/main.as
@@ -321,7 +321,7 @@ void RenderActions()
 
 void SetTarget(Target @target) 
 {
-    if (@currentTarget == @target) {
+    if (@currentTarget == @target && @currentTarget != @pb) {
         return;
     }
     @currentTarget = target;


### PR DESCRIPTION
* SetTarget wouldn't work with PBs because currentTarget and target are both pb, so the deltas were never updated
* Use a newRun flag to know when to check for a new time, and avoid using Ghosts_V2 because it can be unreliable in servers

Closes #31
Closes #37
Closes #46
Closes #47

P.S.: According to my tests, the duplicated runs are fixed, but I recommend some more testing (especially on Nadeo rooms) to make sure. Logic looks sound though