### PR TITLE
Use SpawnStatus for DNFs, reset on map exit

### DIFF
--- a/src/dnf_detector.as
+++ b/src/dnf_detector.as
@@ -30,4 +30,14 @@ class DnfHandler {
 
         return false;
     }
+
+    void Reset() {
+        last_spawn_status = MLFeed::SpawnStatus::Spawning;
+        is_running = false;
+        last_finish_state = false;
+    }
+
+    bool IsRunning() {
+        return is_running;
+    }
 }

--- a/src/dnf_detector.as
+++ b/src/dnf_detector.as
@@ -1,5 +1,5 @@
 class DnfHandler {
-    protected uint last_start_time = 0;
+    protected MLFeed::SpawnStatus last_spawn_status = MLFeed::SpawnStatus::Spawning;
     protected bool is_running = false;
     protected bool last_finish_state = false;
 
@@ -8,15 +8,26 @@ class DnfHandler {
         if (cpInfo is null) {
             return false;
         }
-        if (is_running && cpInfo.StartTime > last_start_time) {
-            last_start_time = cpInfo.StartTime;
-            if (!last_finish_state) {
+
+        if (!is_running && UI::CurrentActionMap() != "SpectatorMap" && cpInfo.CurrentRaceTime < 0 && cpInfo.SpawnStatus == MLFeed::SpawnStatus::Spawning) {
+            is_running = true;
+            return false;
+        }
+
+        if (is_running && cpInfo.SpawnStatus != last_spawn_status) {
+            last_spawn_status = cpInfo.SpawnStatus;
+
+            if (!last_finish_state && cpInfo.SpawnStatus == MLFeed::SpawnStatus::Spawning) {
                 return true;
             }
         }
-        is_running = true;
-        last_start_time = cpInfo.StartTime;
-        last_finish_state = cpInfo.IsFinished;
+
+        if (cpInfo.IsFinished) {
+            last_finish_state = true;
+        } else if (cpInfo.SpawnStatus == MLFeed::SpawnStatus::Spawned) {
+            last_finish_state = false;
+        }
+
         return false;
     }
 }

--- a/src/main.as
+++ b/src/main.as
@@ -79,7 +79,7 @@ void Main()
         yield();
 
         auto race = MLFeed::GetRaceData_V4();
-        auto playerData = race.GetPlayer_V4(MLFeed::LocalPlayersName);
+        auto playerData = race.LocalPlayer;
         if (playerData !is null) {
             // print(playerData.spawnIndex);
             if (runs.current !is null) {
@@ -433,7 +433,7 @@ void OnFinishedRun(const int lastTime)
 
     
     auto raceData = MLFeed::GetRaceData_V4();
-    auto playerData = raceData.GetPlayer_V4(MLFeed::LocalPlayersName);
+    auto playerData = raceData.LocalPlayer;
     if (playerData !is null) {
         auto noRespawnTime = playerData.LastTheoreticalCpTime;
         auto norespawnTarget = GetHardestMedalBeaten(noRespawnTime);

--- a/src/main.as
+++ b/src/main.as
@@ -120,6 +120,8 @@ void Main()
                 lastMapId = map.MapInfo.MapUid;
                 OnMapChange(map);
             }
+        } else if (dnf_handler.IsRunning()) {
+             dnf_handler.Reset();
         }
     }
 }


### PR DESCRIPTION
I found two reasons why DNFs could be added before we start a run:
* Values weren't being reset after exiting a map, so the DNF handler was already running when opening the next map
* Servers can be weird about runs. When you join a server, the intro starts playing, but MLFeed values returned reflect a new run, as seen here (see values on the right)

![image](https://github.com/user-attachments/assets/cead4a25-a7c5-450b-8695-407fd6b9ba52)

The solution I found was to check for the first countdown, which should indicate the first real run in a server. A countdown is detected by checking for CurrentRaceTime < 0, which we now do in this check

```cpp
if (!is_running && UI::CurrentActionMap() != "SpectatorMap" && cpInfo.CurrentRaceTime < 0 && cpInfo.SpawnStatus == MLFeed::SpawnStatus::Spawning) {
	is_running = true;
	return false;
}
```

the other 2 checks are mostly failsafes just in case. "SpectatorMap" is returned when the intro is playing, which we want to avoid

I tested the changes in solo, the Openplanet Nadeo server, and the dedicated one, and they all worked fine. I still recommend testing just in case

Fixes #44

P.S.: These changes require the new MLFeed 0.6.0 update